### PR TITLE
Publish to Pandell MyGet repo

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,16 +9,23 @@ jobs:
       contents: read
       packages: write
     steps:
+    # publish to GitHub package repository
     - uses: actions/checkout@v2
-    # Setup .npmrc file to publish to GitHub Packages
     - uses: actions/setup-node@v2
       with:
         node-version: '16.x'
         registry-url: 'https://npm.pkg.github.com'
-        # Defaults to the user or organization that owns the workflow file
         scope: '@pandell'
     - run: yarn
     - run: yarn build
     - run: yarn publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # publish to Pandell's MyGet package repository
+    - uses: actions/setup-node@v2
+      with:
+        registry-url: 'https://www.myget.org/F/pandell-npm/npm/'
+        scope: '@pandell'
+    - run: yarn publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.MYGET_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,5 @@
   "eslint.validate": ["javascript", "typescript"],
 
   // spell-checking extension settings
-  "cSpell.words": ["esbuild", "Maechler", "mockdata", "pandell", "teamcity"]
+  "cSpell.words": ["esbuild", "maechler", "mockdata", "myget", "pandell", "teamcity"]
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "lint": "eslint --max-warnings 0 --ext \".js,.ts\" --cache .",
     "test": "yarn build && jest",
     "verify": "yarn test && yarn lint && yarn format",
-    "postversion": "git push --tags && yarn publish . --tag $npm_package_version && git push && echo \"Successfully released version $npm_package_version!\"",
     "watch": "tsc --watch"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pandell/jest-teamcity",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Modern Jest Test Result Processor for TeamCity",
   "keywords": [
     "jest",


### PR DESCRIPTION
Adjusts the publish workflow to also publish npm packages to Pandell's private npm repository on MyGet.

Closes #6.