### PR TITLE
Fix Publish Workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -16,6 +16,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "@pandell"
       - run: yarn
-      - run: yarn publish
+      - run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/jest-teamcity",
   "type": "module",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "packageManager": "yarn@4.3.1",
   "description": "Modern Jest Test Result Processor for TeamCity",
   "keywords": [


### PR DESCRIPTION
Update publish workflow from [yarn publish](https://classic.yarnpkg.com/lang/en/docs/cli/publish/) to [yarn npm publish](https://yarnpkg.com/cli/npm/publish) and increment the patch version to "0.4.1".