### PR TITLE
Switch to npm publish

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -16,6 +16,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "@pandell"
       - run: yarn
-      - run: yarn npm publish
+      - run: yarn pack
+      - run: npm publish package.tgz
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_//registry.npmjs.org/:_authToken: ${{ secrets.NPM_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,7 @@
     "maechler",
     "mockdata",
     "myget",
+    "npmjs",
     "npmrc",
     "outdir",
     "pandell",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pandell/jest-teamcity",
   "type": "module",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "packageManager": "yarn@4.3.1",
   "description": "Modern Jest Test Result Processor for TeamCity",
   "keywords": [


### PR DESCRIPTION
- Switch to `yarn pack` & `npm publish package.tgz`
- Use `NPM_CONFIG_//registry.npmjs.org/:_authToken` to set the auth token
- Update the `NPM_TOKEN` and verify with [GitHub Action experiment](https://github.com/pandell/jest-teamcity/actions/runs/9999128307/job/27639504319)